### PR TITLE
v1.7.0 add flags for force-reauth and session-duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+### 1.7.0
+* Add `--always-auth` `-a` flag to not check keyring for cached creds (but still try to store them)
+* Add `--session-duration` `-t` flag to request a different token lifetime, up to 12 hours (may not be granted)
+* Add support for session duration in aliases
+* Add `max-duration` subcommand to return the maximum possible session duration request for a profile
+* `each` subcommand no longer prints each role to stdout as it iterates
+
+### 1.6.1
+* Bugfix for `each` subcommand with exit codes
+
+### 1.6.0
+* [internal] migration to go modules
+
+### 1.5.0
+* Better handling of pipes (in and out) and exit codes
+
+### 1.4.3
+* Allow `--region` `-r` to be used at top level
+
 ### 1.4.2
 * Update the aws-sdk-go, gomock, and logrus versions.
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -26,12 +26,14 @@ func makeProvider() (*provider.Provider, error) {
 		}
 	}
 	a := &provider.AwsProvider{
-		Keyring: kr,
-		Region:  region,
+		Keyring:  kr,
+		Region:   region,
+		Duration: int64(duration),
 	}
 	return &provider.Provider{
-		A: a,
-		K: k,
+		A:          a,
+		K:          k,
+		AlwaysAuth: alwaysAuth,
 	}, nil
 }
 

--- a/cmd/each.go
+++ b/cmd/each.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"fmt"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 
 	"github.com/spf13/cobra"
@@ -40,7 +40,7 @@ func runEach(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		p := re.FindStringSubmatch(role)
-		fmt.Printf("%s\n", p[1])
+		log.Infof("%s\n", p[1])
 		awsrole = p[1]
 		err = runWithAwsEnv(true, args[0], args[1:]...)
 		if err != nil {

--- a/cmd/each.go
+++ b/cmd/each.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	log "github.com/sirupsen/logrus"
 	"regexp"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/each.go
+++ b/cmd/each.go
@@ -19,7 +19,7 @@ var eachCmd = &cobra.Command{
 }
 
 func init() {
-	eachCmd.PersistentFlags().StringVarP(&eachFilter, "filter", "f", "", "Regex to filter listed roles (eg. 'admin')")
+	eachCmd.PersistentFlags().StringVarP(&eachFilter, "filter", "f", "", "Regex to filter listed roles (eg. 'admin').")
 	RootCmd.AddCommand(eachCmd)
 }
 
@@ -40,7 +40,7 @@ func runEach(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		p := re.FindStringSubmatch(role)
-		log.Infof("%s\n", p[1])
+		log.Infof("role %s\n", p[1])
 		awsrole = p[1]
 		err = runWithAwsEnv(true, args[0], args[1:]...)
 		if err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,7 +19,7 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
-	listCmd.PersistentFlags().StringVarP(&listFilter, "filter", "f", "", "Regex to filter listed roles (eg. 'admin')")
+	listCmd.PersistentFlags().StringVarP(&listFilter, "filter", "f", "", "Regex to filter listed roles (eg. 'admin').")
 	RootCmd.AddCommand(listCmd)
 }
 

--- a/cmd/max-duration.go
+++ b/cmd/max-duration.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -22,9 +21,6 @@ func init() {
 func runMaxDCmd(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		return fmt.Errorf("%s does not take any arguments", cmd.Use)
-	}
-	if !regexp.MustCompile("^[a-z-]+$").MatchString(awsrole) {
-		return fmt.Errorf("%s is not a valid role to request", awsrole)
 	}
 	args = strings.Split(fmt.Sprintf("iam get-role --role-name keycloak-%s --query Role.MaxSessionDuration", awsrole), " ")
 	return runWithAwsEnv(false, "aws", args...)

--- a/cmd/max-duration.go
+++ b/cmd/max-duration.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var maxDCmd = &cobra.Command{
+	Use:     "max-duration",
+	Short:   "Figure out the maximum duration you can request for a session with this role.",
+	Example: "  aws-keycloak -p power-devx max-duration",
+	RunE:    runMaxDCmd,
+}
+
+func init() {
+	RootCmd.AddCommand(maxDCmd)
+}
+
+func runMaxDCmd(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("%s does not take any arguments", cmd.Use)
+	}
+	if !regexp.MustCompile("^[a-z-]+$").MatchString(awsrole) {
+		return fmt.Errorf("%s is not a valid role to request", awsrole)
+	}
+	args = strings.Split(fmt.Sprintf("iam get-role --role-name keycloak-%s --query Role.MaxSessionDuration", awsrole), " ")
+	return runWithAwsEnv(false, "aws", args...)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,8 +22,9 @@ var (
 )
 
 const (
-	KeycloakConfigUrl = "https://wiki.corp.mulesoft.com/download/attachments/53909517/keycloak-config?api=v2"
-	KeycloakVersion   = "1.6.1"
+	KeycloakConfigUrl          = "https://wiki.corp.mulesoft.com/download/attachments/53909517/keycloak-config?api=v2"
+	KeycloakVersion            = "1.7.0"
+	DefaultSAMLSessionDuration = 3600
 )
 
 // global flags
@@ -32,6 +33,8 @@ var (
 	kr         keyring.Keyring
 	debug      bool
 	quiet      bool
+	alwaysAuth bool
+	duration   uint
 	configFile string
 	kcprofile  string
 	awsrole    string
@@ -154,13 +157,15 @@ func init() {
 	for _, backendType := range keyring.AvailableBackends() {
 		backendsAvailable = append(backendsAvailable, string(backendType))
 	}
-	RootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", provider.DefaultConf, "Keycloak provider configuration")
-	RootCmd.PersistentFlags().StringVarP(&backend, "backend", "b", "", fmt.Sprintf("Secret backend to use %s", backendsAvailable))
-	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable debug output")
-	RootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Minimize output")
-	RootCmd.PersistentFlags().StringVarP(&kcprofile, "keycloak-profile", "k", provider.DefaultKeycloak, "Keycloak system to auth to")
-	RootCmd.PersistentFlags().StringVarP(&awsrole, "profile", "p", "", "AWS profile to run against (recommended)")
-	RootCmd.PersistentFlags().StringVarP(&regionFlag, "region", "r", "", "AWS region to use (overrides alias settings)")
+	RootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", provider.DefaultConf, "Keycloak provider configuration.")
+	RootCmd.PersistentFlags().StringVarP(&backend, "backend", "b", "", fmt.Sprintf("Secret backend to use %s.", backendsAvailable))
+	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable debug output.")
+	RootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Minimize output.")
+	RootCmd.PersistentFlags().StringVarP(&kcprofile, "keycloak-profile", "k", provider.DefaultKeycloak, "Keycloak system to auth to.")
+	RootCmd.PersistentFlags().StringVarP(&awsrole, "profile", "p", "", "AWS profile to run against (recommended).")
+	RootCmd.PersistentFlags().StringVarP(&regionFlag, "region", "r", "", "AWS region to use (overrides alias settings).")
+	RootCmd.PersistentFlags().BoolVarP(&alwaysAuth, "always-auth", "a", false, "Do no use cached token, always force new SAML authentication.")
+	RootCmd.PersistentFlags().UintVarP(&duration, "session-duration", "t", DefaultSAMLSessionDuration, "Requested session duration in seconds. Max is 12 hours (43200).")
 }
 
 func fetchConfig() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -167,7 +167,7 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Minimize output.")
 	RootCmd.PersistentFlags().StringVarP(&kcprofile, "keycloak-profile", "k", provider.DefaultKeycloak, "Keycloak system to auth to.")
 	RootCmd.PersistentFlags().StringVarP(&awsrole, "profile", "p", "", "AWS profile to run against (recommended).")
-	RootCmd.PersistentFlags().StringVarP(&regionFlag, "region", "r", "", "AWS region to use (overrides alias settings).")
+	RootCmd.PersistentFlags().StringVarP(&regionFlag, "region", "r", "", fmt.Sprintf("AWS region to use (overrides alias settings). Default %s", provider.DefaultRegion))
 	RootCmd.PersistentFlags().BoolVarP(&alwaysAuth, "always-auth", "a", false, "Do no use cached token, always force new SAML authentication.")
 	RootCmd.PersistentFlags().Uint64VarP(&duration, "session-duration", "t", provider.DefaultSAMLSessionDuration, "Requested session duration in seconds. Max is 12 hours (43200).")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,9 +22,8 @@ var (
 )
 
 const (
-	KeycloakConfigUrl          = "https://wiki.corp.mulesoft.com/download/attachments/53909517/keycloak-config?api=v2"
-	KeycloakVersion            = "1.7.0"
-	DefaultSAMLSessionDuration = 3600
+	KeycloakConfigUrl = "https://wiki.corp.mulesoft.com/download/attachments/53909517/keycloak-config?api=v2"
+	KeycloakVersion   = "1.7.0"
 )
 
 // global flags
@@ -34,7 +33,7 @@ var (
 	debug      bool
 	quiet      bool
 	alwaysAuth bool
-	duration   uint
+	duration   uint64
 	configFile string
 	kcprofile  string
 	awsrole    string
@@ -137,8 +136,8 @@ func prerun(cmd *cobra.Command, args []string) error {
 	aliases := provider.Aliases(sections["aliases"])
 	if aliases.Exists(awsrole) {
 		alias := awsrole
-		kcprofile, awsrole, region = aliases.Lookup(alias)
-		log.Debugf("Found alias for %s: %s %s %s", alias, kcprofile, awsrole, region)
+		kcprofile, awsrole, region, duration = aliases.Lookup(alias)
+		log.Debugf("Found alias for %s: %s %s %s %d", alias, kcprofile, awsrole, region, duration)
 	}
 	if regionFlag != "" {
 		region = regionFlag
@@ -165,7 +164,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&awsrole, "profile", "p", "", "AWS profile to run against (recommended).")
 	RootCmd.PersistentFlags().StringVarP(&regionFlag, "region", "r", "", "AWS region to use (overrides alias settings).")
 	RootCmd.PersistentFlags().BoolVarP(&alwaysAuth, "always-auth", "a", false, "Do no use cached token, always force new SAML authentication.")
-	RootCmd.PersistentFlags().UintVarP(&duration, "session-duration", "t", DefaultSAMLSessionDuration, "Requested session duration in seconds. Max is 12 hours (43200).")
+	RootCmd.PersistentFlags().Uint64VarP(&duration, "session-duration", "t", provider.DefaultSAMLSessionDuration, "Requested session duration in seconds. Max is 12 hours (43200).")
 }
 
 func fetchConfig() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/99designs/keyring"
 	log "github.com/sirupsen/logrus"
@@ -131,6 +132,10 @@ func prerun(cmd *cobra.Command, args []string) error {
 	// So hacky!
 	if cmd == openCmd && len(args) == 1 {
 		awsrole = args[0]
+	}
+
+	if !regexp.MustCompile("^[a-z-]+$").MatchString(awsrole) {
+		return fmt.Errorf("'%s' is not a valid role to request. Try `power-devx`.", awsrole)
 	}
 
 	aliases := provider.Aliases(sections["aliases"])

--- a/provider/aliases.go
+++ b/provider/aliases.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"strconv"
 	"strings"
 )
 
 const (
-	DefaultRegion   = "us-east-1"
-	DefaultKeycloak = "id"
+	DefaultRegion              = "us-east-1"
+	DefaultKeycloak            = "id"
+	DefaultSAMLSessionDuration = 3600
 )
 
 type Aliases map[string]string
@@ -16,13 +18,16 @@ func (as Aliases) Exists(alias string) bool {
 	return exists
 }
 
-func (as Aliases) Lookup(alias string) (kcprofile, awsrole, region string) {
+func (as Aliases) Lookup(alias string) (kcprofile, awsrole, region string, duration uint64) {
 	s := strings.Split(as[alias], ":")
 	kcprofile = s[0]
 	awsrole = s[1]
-	if len(s) == 3 {
+	if len(s) >= 3 {
 		region = s[2]
 	}
 	// else region is empty
+	if len(s) >= 4 {
+		duration, _ = strconv.ParseUint(s[2], 10, 64)
+	}
 	return
 }

--- a/provider/aliases.go
+++ b/provider/aliases.go
@@ -27,7 +27,7 @@ func (as Aliases) Lookup(alias string) (kcprofile, awsrole, region string, durat
 	}
 	// else region is empty
 	if len(s) >= 4 {
-		duration, _ = strconv.ParseUint(s[2], 10, 64)
+		duration, _ = strconv.ParseUint(s[3], 10, 64)
 	}
 	return
 }

--- a/provider/aliases_test.go
+++ b/provider/aliases_test.go
@@ -1,0 +1,42 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mulesoft-labs/aws-keycloak/provider"
+)
+
+func testAlias(a provider.Aliases, alias, _kcprofile, _awsrole, _region string, _duration uint64) error {
+	kcprofile, awsrole, region, duration := a.Lookup(alias)
+	if kcprofile != _kcprofile {
+		return fmt.Errorf("kcprofile does not match expected. actual: %s - expected: %s", kcprofile, _kcprofile)
+	}
+	if awsrole != _awsrole {
+		return fmt.Errorf("awsrole does not match expected. actual: %s - expected: %s", awsrole, _awsrole)
+	}
+	if region != _region {
+		return fmt.Errorf("region does not match expected. actual: %s - expected: %s", region, _region)
+	}
+	if duration != _duration {
+		return fmt.Errorf("duration does not match expected. actual: %d - expected: %d", duration, _duration)
+	}
+	return nil
+}
+
+func TestAliasMulti(t *testing.T) {
+	a := provider.Aliases{
+		"t2": "id:power-devx",
+		"t3": "id:power-devx:us-east-1",
+		"t4": "id:power-devx:us-east-1:7200",
+	}
+	if err := testAlias(a, "t2", "id", "power-devx", "", 0); err != nil {
+		t.Error(err)
+	}
+	if err := testAlias(a, "t3", "id", "power-devx", "us-east-1", 0); err != nil {
+		t.Error(err)
+	}
+	if err := testAlias(a, "t4", "id", "power-devx", "us-east-1", 7200); err != nil {
+		t.Error(err)
+	}
+}

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -13,10 +13,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	awsDuration = 3600
-)
-
 type AwsProviderIf interface {
 	AssumeRoleWithSAML(saml.RolePrincipal, string) (sts.Credentials, error)
 	CheckAlreadyAuthd(string) (sts.Credentials, error)
@@ -24,8 +20,9 @@ type AwsProviderIf interface {
 }
 
 type AwsProvider struct {
-	Keyring keyring.Keyring
-	Region  string
+	Keyring  keyring.Keyring
+	Region   string
+	Duration int64 // this sets the maximum request, not necessarily what will be granted
 }
 
 func (a *AwsProvider) AssumeRoleWithSAML(rp saml.RolePrincipal, assertion string) (sts.Credentials, error) {
@@ -38,7 +35,7 @@ func (a *AwsProvider) AssumeRoleWithSAML(rp saml.RolePrincipal, assertion string
 		PrincipalArn:    aws.String(rp.Principal),
 		RoleArn:         aws.String(rp.Role),
 		SAMLAssertion:   aws.String(assertion),
-		DurationSeconds: aws.Int64(awsDuration),
+		DurationSeconds: aws.Int64(a.Duration),
 	}
 
 	samlResp, err := svc.AssumeRoleWithSAML(samlParams)


### PR DESCRIPTION
* add flag `--force-reauth` to not lookup stored credential in keyring (will still store it)
* add flag `--session-duration` to request different token lifetime, up to 12 hours